### PR TITLE
Added QStringBuilder include for build on windows

### DIFF
--- a/src/sender.cpp
+++ b/src/sender.cpp
@@ -17,6 +17,7 @@
 
 #include "sender_p.h"
 
+#include <QStringBuilder>
 #include <QLoggingCategory>
 
 Q_LOGGING_CATEGORY(SIMPLEMAIL_SENDER, "simplemail.sender")


### PR DESCRIPTION
Compiler threw error on '%'-operator concatenated string. Fixed by explicitly including QStringBuilder.