### PR TITLE
Added seek(0) to MimePart::content() equivalent to MimePart::data()

### DIFF
--- a/src/mimepart.cpp
+++ b/src/mimepart.cpp
@@ -71,7 +71,7 @@ QByteArray MimePart::header() const
 QByteArray MimePart::content() const
 {
     Q_D(const MimePart);
-    if (d->contentDevice) {
+    if (d->contentDevice && d->contentDevice->seek(0)) {
         return d->contentDevice->readAll();
     }
     return QByteArray();


### PR DESCRIPTION
We save sent mails into a mailarchive, we cannot yet retrieve binary content (attachments/files) after mail has been sent, since MimePart::content() did not seek(0) before. With this change one can simply recreate the MimePart by saving all properties including QByteArray-content to db.