### PR TITLE
Added missing implementation for assignment operator required for MSVC2017 Qt5.9 64bit

### DIFF
--- a/src/mimepart.cpp
+++ b/src/mimepart.cpp
@@ -39,6 +39,19 @@ MimePart::~MimePart()
     qDebug() << Q_FUNC_INFO;
 }
 
+MimePart &MimePart::operator=(const MimePart &other)
+{
+    setCharset(other.charset());
+    setContent(other.content());
+    setContentId(other.contentId());
+    setContentName(other.contentName());
+    setContentType(other.contentType());
+    setEncoding(other.encoding());
+    setHeader(other.header());
+
+    return *this;
+}
+
 void MimePart::setContent(const QByteArray &content)
 {
     Q_D(MimePart);


### PR DESCRIPTION
We successfully use SimpleMail with MinGW Builds on windows. Now trying to compile this with MSVC2017 for Qt5.9 we found the MimePart was missing an implementation for the assignment operator. We added the implementation and SimpleMail now correctly compiles on MSVC2017 as it does for MinGW