### PR TITLE
Allow ignoring ssl errors on faulty server configurations

### DIFF
--- a/src/sender.cpp
+++ b/src/sender.cpp
@@ -138,6 +138,7 @@ void Sender::setConnectionType(ConnectionType connectionType)
     case SslConnection:
     case TlsConnection:
         d->socket = new QSslSocket(this);
+        connect(static_cast<QSslSocket*>(d->socket), static_cast<void(QSslSocket::*)(const QList<QSslError> &)>(&QSslSocket::sslErrors),this, &Sender::sslErrors, Qt::DirectConnection);
     }
     connect(d->socket, &QTcpSocket::stateChanged, this, &Sender::socketStateChanged);
     connect(d->socket, static_cast<void(QTcpSocket::*)(QTcpSocket::SocketError)>(&QTcpSocket::error),
@@ -195,6 +196,24 @@ void Sender::setSendMessageTimeout(int msec)
 {
     Q_D(Sender);
     d->sendMessageTimeout = msec;
+}
+
+void Sender::ignoreSslErrors()
+{
+    Q_D(Sender);
+    if (connectionType() == SslConnection || connectionType() == TlsConnection)
+    {
+        static_cast<QSslSocket*>(d->socket)->ignoreSslErrors();
+    }
+}
+
+void Sender::ignoreSslErrors(const QList<QSslError> &errors)
+{
+    Q_D(Sender);
+    if (connectionType() == SslConnection || connectionType() == TlsConnection)
+    {
+        static_cast<QSslSocket*>(d->socket)->ignoreSslErrors(errors);
+    }
 }
 
 bool Sender::sendMail(MimeMessage &email)

--- a/src/sender.h
+++ b/src/sender.h
@@ -172,6 +172,19 @@ public:
      */
     void setSendMessageTimeout(int msec);
 
+    /**
+     * @brief ignoreSslErrors tells the socket to ignore all pending ssl errors if SSL encryption is active.
+     *      Must be called in a direct connected slot/functor
+     */
+    void ignoreSslErrors();
+
+    /**
+     * @brief ignoreSslErrors tells the socket to ignore the given ssl errors if SSL encryption is active.
+     *      Must be called in a direct connected slot/functor
+     * @param errors defines the errors to ignore
+     */
+    void ignoreSslErrors(const QList<QSslError> &errors);
+
     bool sendMail(MimeMessage &email);
 
     QString lastError() const;
@@ -185,6 +198,7 @@ protected Q_SLOTS:
 
 Q_SIGNALS:
     void smtpError(SmtpError e);
+    void sslErrors(const QList<QSslError> &sslErrorList);
 
 protected:
     SenderPrivate *d_ptr;


### PR DESCRIPTION
This will allow implementing slots for ignoring SSL/TLS errors on faulty server configurations.
Most seen cases are:
- Self signed certificates
- Wrong hostnames (certificates without wildcards and mx/mail subdomain)
- SSL proxy/tunnel certs