### PR TITLE
Added option to define the peer verification mode

### DIFF
--- a/src/mimepart.cpp
+++ b/src/mimepart.cpp
@@ -31,13 +31,21 @@ MimePart::MimePart() : d_ptr(new MimePartPrivate)
 
 MimePart::MimePart(const MimePart &other)
 {
-    setCharset(other.charset());
-    setContent(other.content());
-    setContentId(other.contentId());
-    setContentName(other.contentName());
-    setContentType(other.contentType());
-    setEncoding(other.encoding());
-    setHeader(other.header());
+    Q_D(MimePart);
+    d->contentCharset = other.charset();
+
+    if (d->contentDevice) {
+        delete d->contentDevice;
+    }
+    d->contentDevice = new QBuffer;
+    d->contentDevice->open(QBuffer::ReadWrite);
+    d->contentDevice->write(other.content());
+
+    d->contentId = other.contentId();
+    d->contentName = other.contentName();
+    d->contentType = other.contentType();
+    d->contentEncoding = other.encoding();
+    d->header = other.header();
 }
 
 MimePart::~MimePart()
@@ -47,13 +55,21 @@ MimePart::~MimePart()
 
 MimePart &MimePart::operator=(const MimePart &other)
 {
-    setCharset(other.charset());
-    setContent(other.content());
-    setContentId(other.contentId());
-    setContentName(other.contentName());
-    setContentType(other.contentType());
-    setEncoding(other.encoding());
-    setHeader(other.header());
+    Q_D(MimePart);
+    d->contentCharset = other.charset();
+
+    if (d->contentDevice) {
+        delete d->contentDevice;
+    }
+    d->contentDevice = new QBuffer;
+    d->contentDevice->open(QBuffer::ReadWrite);
+    d->contentDevice->write(other.content());
+
+    d->contentId = other.contentId();
+    d->contentName = other.contentName();
+    d->contentType = other.contentType();
+    d->contentEncoding = other.encoding();
+    d->header = other.header();
 
     return *this;
 }

--- a/src/mimepart.cpp
+++ b/src/mimepart.cpp
@@ -31,7 +31,13 @@ MimePart::MimePart() : d_ptr(new MimePartPrivate)
 
 MimePart::MimePart(const MimePart &other)
 {
-    qDebug() << Q_FUNC_INFO;
+    setCharset(other.charset());
+    setContent(other.content());
+    setContentId(other.contentId());
+    setContentName(other.contentName());
+    setContentType(other.contentType());
+    setEncoding(other.encoding());
+    setHeader(other.header());
 }
 
 MimePart::~MimePart()

--- a/src/sender.h
+++ b/src/sender.h
@@ -38,6 +38,7 @@ public:
         AuthPlain,
         AuthLogin
     };
+    Q_ENUM(AuthMethod)
 
     enum SmtpError
     {
@@ -48,6 +49,7 @@ public:
         ServerError,    // 4xx smtp error
         ClientError     // 5xx smtp error
     };
+    Q_ENUM(SmtpError)
 
     enum ConnectionType
     {
@@ -55,12 +57,14 @@ public:
         SslConnection,
         TlsConnection       // STARTTLS
     };
+    Q_ENUM(ConnectionType)
 
     enum PeerVerificationType
     {
         VerifyNone,
         VerifyPeer
     };
+    Q_ENUM(PeerVerificationType)
 
     explicit Sender(QObject *parent = 0);
     Sender(const QString &host, int port, ConnectionType ct, QObject *parent = 0);

--- a/src/sender.h
+++ b/src/sender.h
@@ -56,6 +56,12 @@ public:
         TlsConnection       // STARTTLS
     };
 
+    enum PeerVerificationType
+    {
+        VerifyNone,
+        VerifyPeer
+    };
+
     explicit Sender(QObject *parent = 0);
     Sender(const QString &host, int port, ConnectionType ct, QObject *parent = 0);
     virtual ~Sender();
@@ -184,6 +190,18 @@ public:
      * @param errors defines the errors to ignore
      */
     void ignoreSslErrors(const QList<QSslError> &errors);
+
+    /**
+     * @brief setPeerVerificationType Defines how the mail-server's SSL certificate should be examined
+     * @param type  VerifyNone does not try to verify the identity, VerifyPeer does check on server identity
+     */
+    void setPeerVerificationType(PeerVerificationType type);
+
+    /**
+     * @brief peerVerificationType Returns the type of verification done for the mail-server's SSL certificate
+     * @return PeerVerificationType as VerifyNone or VerifyPeer
+     */
+    PeerVerificationType peerVerificationType();
 
     bool sendMail(MimeMessage &email);
 

--- a/src/sender_p.h
+++ b/src/sender_p.h
@@ -44,6 +44,7 @@ public:
     bool login();
     bool waitForResponse(int expectedCode);
     bool processState();
+    void setPeerVerificationType(const Sender::PeerVerificationType &type);
 
     State state = State::Disconnected;
     Sender *q_ptr;
@@ -54,6 +55,7 @@ public:
     int port = 25;
     Sender::ConnectionType connectionType;
     QString name = QHostInfo::localHostName();
+    Sender::PeerVerificationType peerVerificationType = Sender::VerifyPeer;
 
     QString user;
     QString password;
@@ -62,7 +64,6 @@ public:
     int connectionTimeout = 5000;
     int responseTimeout = 5000;
     int sendMessageTimeout = 60000;
-
 
     QByteArray responseText;
     int responseCode;


### PR DESCRIPTION
Setting the peer verification mode enables the client to connect to non-identifiable servers (broken server certificates)

- Implemented support for PeerVerfication settings
- Added missing copy constructor for MimePart
- Fixed call to QAbstractSocket class method disconnect(FromHost) socket from host