### PR TITLE
 Add Date: header field as required by RFC5322 

### DIFF
--- a/src/mimemessage.cpp
+++ b/src/mimemessage.cpp
@@ -90,8 +90,7 @@ bool MimeMessage::write(QIODevice *device)
     if (utcOffset == 0) {
         data.append(QByteArrayLiteral("+0000"));
     } else {
-        const bool negative = (utcOffset < 0);
-        if (negative) {
+        if (utcOffset < 0) {
             data.append('-');
             utcOffset *= -1;
         } else {

--- a/src/mimemessage.cpp
+++ b/src/mimemessage.cpp
@@ -84,21 +84,7 @@ bool MimeMessage::write(QIODevice *device)
         return false;
     }
 
-    const auto dt = QDateTime::currentDateTime();
-    data = QByteArrayLiteral("Date: ") + QLocale::c().toString(dt, QStringLiteral("ddd, d MMM yyyy HH:mm:ss ")).toLatin1();
-    int utcOffset = dt.offsetFromUtc();
-    if (utcOffset == 0) {
-        data.append(QByteArrayLiteral("+0000"));
-    } else {
-        if (utcOffset < 0) {
-            data.append('-');
-            utcOffset *= -1;
-        } else {
-            data.append('+');
-        }
-        const auto offsetTime = QTime::fromMSecsSinceStartOfDay(utcOffset * 1000);
-        data.append(offsetTime.toString(QStringLiteral("HHmm")).toLatin1());
-    }
+    data = QByteArrayLiteral("Date: ") + QLocale::c().toString(QDateTime::currentDateTimeUtc(), QStringLiteral("ddd, d MMM yyyy HH:mm:ss +0000")).toLatin1();
     if (device->write(data) != data.size()) {
         return false;
     }

--- a/src/mimemessage.cpp
+++ b/src/mimemessage.cpp
@@ -23,7 +23,6 @@ x
 #include <typeinfo>
 
 #include <QDateTime>
-#include <QLocale>
 #include <QLoggingCategory>
 
 Q_LOGGING_CATEGORY(SIMPLEMAIL_MIMEMSG, "simplemail.mimemessage")
@@ -84,7 +83,7 @@ bool MimeMessage::write(QIODevice *device)
         return false;
     }
 
-    data = QByteArrayLiteral("Date: ") + QLocale::c().toString(QDateTime::currentDateTimeUtc(), QStringLiteral("ddd, d MMM yyyy HH:mm:ss +0000")).toLatin1();
+    data = QByteArrayLiteral("Date: ") + QDateTime::currentDateTime().toString(Qt::RFC2822Date).toLatin1();
     if (device->write(data) != data.size()) {
         return false;
     }

--- a/src/mimemessage.cpp
+++ b/src/mimemessage.cpp
@@ -83,7 +83,7 @@ bool MimeMessage::write(QIODevice *device)
         return false;
     }
 
-    data = QByteArrayLiteral("Date: ") + QDateTime::currentDateTime().toString(Qt::RFC2822Date).toLatin1();
+    data = QByteArrayLiteral("Date: ") + QDateTime::currentDateTime().toString(Qt::RFC2822Date).toLatin1() + QByteArrayLiteral("\r\n");
     if (device->write(data) != data.size()) {
         return false;
     }

--- a/src/mimemessage.cpp
+++ b/src/mimemessage.cpp
@@ -100,6 +100,9 @@ bool MimeMessage::write(QIODevice *device)
         const auto offsetTime = QTime::fromMSecsSinceStartOfDay(utcOffset * 1000);
         data.append(offsetTime.toString(QStringLiteral("HHmm")).toLatin1());
     }
+    if (device->write(data) != data.size()) {
+        return false;
+    }
 
     data = QByteArrayLiteral("Subject: ") + MimeMessagePrivate::encodeData(d->encoding, d->subject, true);
     if (device->write(data) != data.size()) {


### PR DESCRIPTION
RFC5322 defines two field that are mandatory: Date and From. Date was
missing in the current implementation.

See also https://tools.ietf.org/html/rfc5322#section-3.6