### PR TITLE
Fix wrong requirement in pkgconfig file

### DIFF
--- a/src/simplemail-qt5.pc.in
+++ b/src/simplemail-qt5.pc.in
@@ -6,6 +6,6 @@ includedir=${prefix}/include
 Name: simplemail-qt5
 Description: SimpleMail library for Qt5
 Version: @VERSION@
-Requires: QtCore
+Requires: Qt5Core
 Libs: -L${libdir} -lsimplemail-qt5
 Cflags: -I${includedir}/simplemail-qt5/


### PR DESCRIPTION
Should require Qt5Core instead of QtCore. The latter one tries to pull
Qt4 in. (found while removing Qt4 from my system after is has been
abandoned on openSUSE)