### PR TITLE
Add GNUInstallDirs to CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 project(libsimplemail VERSION 2.0.0 LANGUAGES CXX)
 
+include(GNUInstallDirs)
+
 set(CMAKE_AUTOMOC ON)
 
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)


### PR DESCRIPTION
CMAKE_INSTALL_LIBDIR doesn't point at /usr/lib64 on 64 bit machines. Adding GNUInstallDirs points the CMake variables at the right directories.