### PR TITLE
Use QtInfoMsg as minimum message type for sender and mimemessage

### DIFF
--- a/src/mimemessage.cpp
+++ b/src/mimemessage.cpp
@@ -25,7 +25,7 @@ x
 #include <QDateTime>
 #include <QLoggingCategory>
 
-Q_LOGGING_CATEGORY(SIMPLEMAIL_MIMEMSG, "simplemail.mimemessage")
+Q_LOGGING_CATEGORY(SIMPLEMAIL_MIMEMSG, "simplemail.mimemessage", QtInfoMsg)
 
 using namespace SimpleMail;
 

--- a/src/sender.cpp
+++ b/src/sender.cpp
@@ -22,7 +22,7 @@
 #include <QLoggingCategory>
 #include <QMessageAuthenticationCode>
 
-Q_LOGGING_CATEGORY(SIMPLEMAIL_SENDER, "simplemail.sender")
+Q_LOGGING_CATEGORY(SIMPLEMAIL_SENDER, "simplemail.sender", QtInfoMsg)
 
 using namespace SimpleMail;
 


### PR DESCRIPTION
SimpleMail::Server already has QtInfoMsg as default minimum category/severity for logging. This adds it also for SimpleMail::Sender and SimpleMail::MimeMessage.