### PR TITLE
Feature/mail queue

### DIFF
--- a/src/sender.cpp
+++ b/src/sender.cpp
@@ -276,6 +276,9 @@ bool SenderPrivate::sendMail(const MimeMessage &email)
 {
     qCDebug(SIMPLEMAIL_SENDER) << "Sending MAIL" << this;
 
+    responseText.clear();
+    responseCode = -1;
+
     if (!processState()) {
         return false;
     }

--- a/src/sender.cpp
+++ b/src/sender.cpp
@@ -172,6 +172,17 @@ int Sender::responseCode() const
     return d->responseCode;
 }
 
+QString SimpleMail::Sender::mailQueueId() const
+{
+    Q_D(const Sender);
+    if (d->responseWithMailQueueId.contains(QLatin1String("queued as"))) {
+        return d->responseWithMailQueueId.section(QLatin1String("queued as"), 1, 1, QString::SectionCaseInsensitiveSeps).trimmed();
+    } else {
+        qCDebug(SIMPLEMAIL_SENDER) << "Response with mail queue ID has unkown format. Returning entire response, must be parsed manually.";
+        return d->responseWithMailQueueId;
+    }
+}
+
 int Sender::connectionTimeout() const
 {
     Q_D(const Sender);
@@ -278,6 +289,7 @@ bool SenderPrivate::sendMail(const MimeMessage &email)
 
     responseText.clear();
     responseCode = -1;
+    responseWithMailQueueId.clear();
 
     if (!processState()) {
         return false;
@@ -341,6 +353,8 @@ bool SenderPrivate::sendMail(const MimeMessage &email)
         return false;
     }
     qCDebug(SIMPLEMAIL_SENDER) << "Mail sent";
+
+    responseWithMailQueueId = QString::fromUtf8(responseText).trimmed();
 
     return true;
 }

--- a/src/sender.h
+++ b/src/sender.h
@@ -154,6 +154,11 @@ public:
     int responseCode() const;
 
     /**
+     * Returns the mail queue ID the SMTP server last returned
+     */
+    QString mailQueueId() const;
+
+    /**
      * Returns the connection timeout when connecting to the SMTP server
      */
     int connectionTimeout() const;

--- a/src/sender_p.h
+++ b/src/sender_p.h
@@ -67,6 +67,7 @@ public:
 
     QByteArray responseText;
     int responseCode = -1;
+    QString responseWithMailQueueId;
 };
 
 }

--- a/src/sender_p.h
+++ b/src/sender_p.h
@@ -66,7 +66,7 @@ public:
     int sendMessageTimeout = 60000;
 
     QByteArray responseText;
-    int responseCode;
+    int responseCode = -1;
 };
 
 }


### PR DESCRIPTION
For documenting purposes and potential debugging it is quite useful to have the mail queue ID at hand. 

This feature adds storing the mail queue ID of the last send() call. 

It also resets members used to store server responses. In case a sender instance is used multiple times they contain information of the last call.