### PR TITLE
Feature/mime type for passing file via stream

### DIFF
--- a/src/mimefile.cpp
+++ b/src/mimefile.cpp
@@ -41,12 +41,19 @@ MimeFile::MimeFile(QFile *file)
     }
 }
 
-MimeFile::MimeFile(const QByteArray &stream, const QString &fileName)
+MimeFile::MimeFile(const QByteArray &stream, const QString &fileName) : MimeFile(stream, fileName, {})
+{
+}
+
+MimeFile::MimeFile(const QByteArray &stream, const QString &fileName, const QByteArray &mimeType)
 {
     Q_D(MimePart);
     d->contentEncoding = Base64;
     d->contentName = fileName.toLatin1();
-    d->contentType = QByteArrayLiteral("application/octet-stream");
+    d->contentType = mimeType;
+    if (d->contentType.isEmpty()) {
+        d->contentType = QByteArrayLiteral("application/octet-stream");
+    }
     setContent(stream);
 }
 

--- a/src/mimefile.h
+++ b/src/mimefile.h
@@ -29,6 +29,7 @@ class SMTP_EXPORT MimeFile : public MimePart
 {
 public:
     MimeFile(const QByteArray &stream, const QString &fileName);
+    MimeFile(const QByteArray &stream, const QString &fileName, const QByteArray &mimeType);
     MimeFile(QFile *f);
     virtual ~MimeFile();
 };

--- a/src/mimeinlinefile.cpp
+++ b/src/mimeinlinefile.cpp
@@ -26,6 +26,12 @@ MimeInlineFile::MimeInlineFile(QFile *f) : MimeFile(f)
     d->header.append(QByteArrayLiteral("Content-Disposition: inline\r\n"));
 }
 
+MimeInlineFile::MimeInlineFile(const QByteArray &stream, const QString &fileName, const QByteArray &mimeType) : MimeFile(stream, fileName, mimeType)
+{
+    Q_D(MimePart);
+    d->header.append(QByteArrayLiteral("Content-Disposition: inline\r\n"));
+}
+
 MimeInlineFile::~MimeInlineFile()
 {
 

--- a/src/mimeinlinefile.h
+++ b/src/mimeinlinefile.h
@@ -28,6 +28,7 @@ class SMTP_EXPORT MimeInlineFile : public MimeFile
 {
 public:
     MimeInlineFile(QFile *f);
+    MimeInlineFile(const QByteArray &stream, const QString &fileName, const QByteArray &mimeType = {});
     virtual ~MimeInlineFile();
 };
 


### PR DESCRIPTION
When storing files not on disk but e.g. in DB, passing files as stream is much easier. 

Since MimeInlineFile sets an additional header adding an additional ctor for streams, also setting this header, is much robust than using MimeFile and doing this all by hand.