### PR TITLE
Implement dot stuffing

### DIFF
--- a/src/mimecontentformatter.cpp
+++ b/src/mimecontentformatter.cpp
@@ -59,6 +59,12 @@ QByteArray MimeContentFormatter::formatQuotedPrintable(const QByteArray &content
             chars = 1;
         }
 
+        // dot stuffing: https://www.rfc-editor.org/rfc/rfc5321#section-4.5.2
+        if (chars == 1 && content[i] == '.') {
+            out.append('.');
+            chars++;
+        }
+
         out.append(content[i]);
     }
 


### PR DESCRIPTION
According to https://www.rfc-editor.org/rfc/rfc5321#section-4.5.2 in case the first char of a line is a period, one additional period has to be inserted at the beginning of the line.