### PR TITLE
Remove sending signal for message end from MimeMessage::write

### DIFF
--- a/src/mimemessage.cpp
+++ b/src/mimemessage.cpp
@@ -126,8 +126,7 @@ bool MimeMessage::write(QIODevice *device) const
         return false;
     }
 
-    // Send \r\n.\r\n to end the mail data
-    return device->write(QByteArrayLiteral("\r\n.\r\n")) == 5;
+    return true;
 }
 
 void MimeMessage::setSender(const EmailAddress &sender)


### PR DESCRIPTION
This is part of the SMTP dialog and should not be handled in the MIME message. The first occurrence of '\r\n.\r\n' will end the SMTP dialog and trigger the 'queued as' response. Sending it a second time has no effect.

The SenderPrivate::sendMail() method also sends the string to signal the end of the message. I am only using the synchronous code path so I am not quite sure how this might impact the `Server` class. IMHO it should be handled where the SMTP dialog is handled, but it would also be possible to leave it in `MimeMessage` and remove it from `Sender` class.