### PR TITLE
[#61] Attachment file with non-ASCII characters in name breaks mail header

### DIFF
--- a/src/mimeattachment.cpp
+++ b/src/mimeattachment.cpp
@@ -26,13 +26,13 @@ MimeAttachment::MimeAttachment(QFile *file) : MimeFile(file)
 {
     Q_D(MimePart);
     const QString filename = QFileInfo(*file).fileName();
-    d->header.append("Content-Disposition: attachment; filename=\"" + filename.toLatin1() + "\"\r\n");
+    d->header.append("Content-Disposition: attachment; filename=\"=?UTF-8?B?" + filename.toUtf8().toBase64(QByteArray::Base64Encoding) + "?=\"\r\n");
 }
 
 MimeAttachment::MimeAttachment(const QByteArray &stream, const QString &fileName): MimeFile(stream, fileName)
 {
     Q_D(MimePart);
-    d->header.append("Content-Disposition: attachment; filename=\"" + fileName.toLatin1() + "\"\r\n");
+    d->header.append("Content-Disposition: attachment; filename=\"=?UTF-8?B?" + fileName.toUtf8().toBase64(QByteArray::Base64Encoding) + "?=\"\r\n");
 }
 
 MimeAttachment::~MimeAttachment()

--- a/src/mimepart.cpp
+++ b/src/mimepart.cpp
@@ -233,7 +233,7 @@ bool MimePart::write(QIODevice *device)
     // Content-Type
     headers.append("Content-Type: " + d->contentType);
     if (!d->contentName.isEmpty()) {
-        headers.append("; name=\"" + d->contentName + "\"");
+        headers.append("; name=\"?UTF-8?B?" + d->contentName.toBase64(QByteArray::Base64Encoding) + "?=\"");
     }
     if (!d->contentCharset.isEmpty()) {
         headers.append("; charset=" + d->contentCharset);


### PR DESCRIPTION
Format the "Content-Type" name and "Content-Disposition" filename
attributes in UTF-8 / base64.