### PR TITLE
Fix error error: C2139: QSslError: undefined class is not allowed as an argument in the compiler internal type characteristic "__is_base_of"

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -17,10 +17,10 @@
 #define SERVER_H
 
 #include <QObject>
+#include <QSslError>
 
 #include "smtpexports.h"
 
-class QSslError;
 namespace SimpleMail {
 
 class MimeMessage;


### PR DESCRIPTION
Very small change to fix the compilation error under Windows using Visual Studio. To all Windows user note that under Windows the Qt OpenSSL library is a separate package that need to be installed separately.ler internal type characteristic "__is_base_of"