### PR TITLE
fix wrong dereferencing

### DIFF
--- a/src/mimemessage.cpp
+++ b/src/mimemessage.cpp
@@ -192,9 +192,11 @@ void MimeMessage::setSubject(const QString &subject)
 
 void MimeMessage::addPart(const std::shared_ptr<MimePart> &part)
 {
-    auto content = *d->content;
-    if (typeid(content) == typeid(MimeMultiPart)) {
-        std::static_pointer_cast<MimeMultiPart>(d->content)->addPart(part);
+    if (d->content) {
+        auto& content = *d->content;
+        if (typeid(content) == typeid(MimeMultiPart)) {
+            std::static_pointer_cast<MimeMultiPart>(d->content)->addPart(part);
+        }
     }
 }
 
@@ -231,11 +233,13 @@ QString MimeMessage::subject() const
 QList<std::shared_ptr<MimePart>> MimeMessage::parts() const
 {
     QList<std::shared_ptr<MimePart>> ret;
-    auto content = *d->content;
-    if (typeid(content) == typeid(MimeMultiPart)) {
-        ret = std::static_pointer_cast<MimeMultiPart>(d->content)->parts();
-    } else {
-        ret.append(std::shared_ptr<MimePart>(d->content));
+    if (d->content) {
+        auto& content = *d->content;
+        if (typeid(content) == typeid(MimeMultiPart)) {
+            ret = std::static_pointer_cast<MimeMultiPart>(d->content)->parts();
+        } else {
+            ret.append(std::shared_ptr<MimePart>(d->content));
+        }
     }
 
     return ret;

--- a/src/mimemessage.cpp
+++ b/src/mimemessage.cpp
@@ -193,7 +193,7 @@ void MimeMessage::setSubject(const QString &subject)
 void MimeMessage::addPart(const std::shared_ptr<MimePart> &part)
 {
     if (d->content) {
-        auto& content = *d->content;
+        auto &content = *d->content;
         if (typeid(content) == typeid(MimeMultiPart)) {
             std::static_pointer_cast<MimeMultiPart>(d->content)->addPart(part);
         }
@@ -234,7 +234,7 @@ QList<std::shared_ptr<MimePart>> MimeMessage::parts() const
 {
     QList<std::shared_ptr<MimePart>> ret;
     if (d->content) {
-        auto& content = *d->content;
+        auto &content = *d->content;
         if (typeid(content) == typeid(MimeMultiPart)) {
             ret = std::static_pointer_cast<MimeMultiPart>(d->content)->parts();
         } else {


### PR DESCRIPTION
Adding parts to MimeMessage does not work. This commit fixes this error.