### PR TITLE
Added multiline support and size validation in mailserver response parsing (220-/250-)

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -580,6 +580,7 @@ bool ServerPrivate::parseResponseCode(int expectedCode,
     while (socket->canReadLine()) {
         // Save the server's response
         const QByteArray responseText = socket->readLine().trimmed();
+        const int responseSize = responseText.size();
         qCDebug(SIMPLEMAIL_SERVER) << "Got response" << responseText << "expected" << expectedCode;
 
         // Extract the respose code from the server's responce (first 3 digits)
@@ -595,7 +596,7 @@ bool ServerPrivate::parseResponseCode(int expectedCode,
             return false;
         }
 
-        if (responseText[3] == '-') {
+        if (responseSize >= 4 && responseText[3] == '-') {
             if (responseCode != expectedCode) {
                 const QString lastError = QString::fromLatin1(responseText);
                 qCWarning(SIMPLEMAIL_SERVER)
@@ -606,7 +607,7 @@ bool ServerPrivate::parseResponseCode(int expectedCode,
             continue;
         }
 
-        if (responseText[3] == ' ') {
+        if (responseSize >= 4 && responseText[3] == ' ') {
             if (responseCode != expectedCode) {
                 const QString lastError = QString::fromLatin1(responseText);
                 qCWarning(SIMPLEMAIL_SERVER)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -577,40 +577,54 @@ bool ServerPrivate::parseResponseCode(int expectedCode,
                                       Server::SmtpError defaultError,
                                       QByteArray *responseMessage)
 {
-    // Save the server's response
-    const QByteArray responseText = socket->readLine().trimmed();
-    qCDebug(SIMPLEMAIL_SERVER) << "Got response" << responseText << "expected" << expectedCode;
+    while (socket->canReadLine()) {
+        // Save the server's response
+        const QByteArray responseText = socket->readLine().trimmed();
+        qCDebug(SIMPLEMAIL_SERVER) << "Got response" << responseText << "expected" << expectedCode;
 
-    // Extract the respose code from the server's responce (first 3 digits)
-    const int responseCode = responseText.left(3).toInt();
+        // Extract the respose code from the server's responce (first 3 digits)
+        const int responseCode = responseText.left(3).toInt();
 
-    if (responseCode / 100 == 4) {
-        failConnection(Server::ServerError, responseCode, QString::fromLatin1(responseText));
-        return false;
-    }
-
-    if (responseCode / 100 == 5) {
-        failConnection(Server::ClientError, responseCode, QString::fromLatin1(responseText));
-        return false;
-    }
-
-    if (responseText[3] == ' ') {
-        if (responseCode != expectedCode) {
-            const QString lastError = QString::fromLatin1(responseText);
-            qCWarning(SIMPLEMAIL_SERVER)
-                << "Unexpected server response" << lastError << expectedCode;
-            failConnection(defaultError, responseCode, lastError);
+        if (responseCode / 100 == 4) {
+            failConnection(Server::ServerError, responseCode, QString::fromLatin1(responseText));
             return false;
         }
-        if (responseMessage) {
-            *responseMessage = responseText.mid(4);
-        }
-        return true;
-    }
 
-    const QString lastError = QString::fromLatin1(responseText);
-    qCWarning(SIMPLEMAIL_SERVER) << "Unexpected server response" << lastError << expectedCode;
-    failConnection(defaultError, responseCode, lastError);
+        if (responseCode / 100 == 5) {
+            failConnection(Server::ClientError, responseCode, QString::fromLatin1(responseText));
+            return false;
+        }
+
+        if (responseText[3] == '-') {
+            if (responseCode != expectedCode) {
+                const QString lastError = QString::fromLatin1(responseText);
+                qCWarning(SIMPLEMAIL_SERVER)
+                    << "Unexpected server response" << lastError << expectedCode;
+                failConnection(defaultError, responseCode, lastError);
+                return false;
+            }
+            continue;
+        }
+
+        if (responseText[3] == ' ') {
+            if (responseCode != expectedCode) {
+                const QString lastError = QString::fromLatin1(responseText);
+                qCWarning(SIMPLEMAIL_SERVER)
+                    << "Unexpected server response" << lastError << expectedCode;
+                failConnection(defaultError, responseCode, lastError);
+                return false;
+            }
+            if (responseMessage) {
+                *responseMessage = responseText.mid(4);
+            }
+            return true;
+        }
+
+        const QString lastError = QString::fromLatin1(responseText);
+        qCWarning(SIMPLEMAIL_SERVER) << "Unexpected server response" << lastError << expectedCode;
+        failConnection(defaultError, responseCode, lastError);
+        return false;
+    }
     return false;
 }
 


### PR DESCRIPTION
**I implemented a loop** over the whole 220/250 response parsing block, automatically **continueing if status followed by -** for identifying a multiline response. Now I additionally **added a size validation for the response** to avoid crashes when referencing into QByteArray by brackets operator using index [3]. Size checking for index [4] is obsolete since bytearray is trimmed and would result in early exit otherwise.